### PR TITLE
2014/10/30公開記事のog:image修正

### DIFF
--- a/source/2014-10-30-development-camp-2014.html.markdown.erb
+++ b/source/2014-10-30-development-camp-2014.html.markdown.erb
@@ -9,14 +9,14 @@ twitter_id: koichiroo
 ogp:
   og:
     image:
-      'sandy beach': http://engineer.crowdworks.jp/images/2014/10/development-camp-2014/05.jpg
-      type: image/png
+      '': http://engineer.crowdworks.jp/images/2014/10/development-camp-2014/05.jpg
+      type: image/jpeg
       width: 800
       height: 600
 atom:
   image:
     url: http://engineer.crowdworks.jp/images/2014/10/development-camp-2014/05.jpg
-    type: image/png
+    type: image/jpeg
 published: true
 ---
 


### PR DESCRIPTION
Open Graph Object Debugger

https://developers.facebook.com/tools/debug/og/object?q=http%3A%2F%2Fengineer.crowdworks.jp%2F2014%2F10%2F30%2Fdevelopment-camp-2014.html

を通してみたところ、指定した画像がロードされていなかった。

> Extraneous Property   Objects of this type do not allow properties named
> 'og:image:sandy beach'.

の指摘を見る限り、'og:image:sandy
beach'ではなく'og:image:'にURLを指定する必要がありそう。
また、これが原因かはわからないが、画像がjpegなのにtypeがimage/pngになってしまっているので、image/jpegに念のため合わせる。
