### PR TITLE
middleman-gemoji を使うように変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "middleman-deploy"
 gem "middleman-s3_sync", "~> 3.0.30"
 gem 'middleman-google-analytics', '~> 1.0.2'
 gem 'middleman-ogp', '~> 1.0.4'
-gem 'middleman-emoji', '~> 0.1.0'
+gem 'middleman-gemoji'
 
 gem "builder", "~> 3.0"
 gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
       fog-core
       fog-json
     formatador (0.2.5)
-    gemoji (1.5.0)
+    gemoji (2.1.0)
     haml (4.0.6)
       tilt
     highline (1.6.21)
@@ -121,9 +121,9 @@ GEM
       middleman-core (>= 3.0.0)
       net-sftp
       ptools
-    middleman-emoji (0.1.0)
-      middleman-core (~> 3.2)
-      rack-emoji (~> 0.1)
+    middleman-gemoji (0.0.5)
+      gemoji (~> 2.1)
+      middleman (~> 3.3)
     middleman-google-analytics (1.0.2)
       middleman-core (~> 3.2)
       uglifier (>= 2.1, < 3.0)
@@ -176,8 +176,6 @@ GEM
     pmap (1.0.1)
     ptools (1.2.4)
     rack (1.6.1)
-    rack-emoji (0.1.0)
-      gemoji (~> 1.5)
     rack-livereload (0.3.15)
       rack
     rack-test (0.6.3)
@@ -265,7 +263,7 @@ DEPENDENCIES
   middleman (~> 3.3.3)
   middleman-blog (~> 3.5.3)
   middleman-deploy
-  middleman-emoji (~> 0.1.0)
+  middleman-gemoji
   middleman-google-analytics (~> 1.0.2)
   middleman-livereload (~> 3.3.4)
   middleman-ogp (~> 1.0.4)
@@ -278,3 +276,6 @@ DEPENDENCIES
   rspec (~> 3.0.0)
   sauce (~> 3.5.0)
   sauce-connect (~> 3.5.0)
+
+BUNDLED WITH
+   1.10.3

--- a/config.rb
+++ b/config.rb
@@ -36,10 +36,7 @@ end
 
 activate :syntax
 
-activate :emoji,
-        dir: ( http_prefix ? "#{http_prefix}" : '') + '/images/emoji',
-        width: 20,
-        height: 20
+activate :gemoji, size: 20, style: 'vertical-align: middle'
 
 set :haml, { ugly: true }
 


### PR DESCRIPTION
いつの間にか middleman-emoji が動かなくなってたっぽいので直しました。
gemoji を使う設定に変えて逃げております :stuck_out_tongue_closed_eyes: 

手元の環境では↓のように見えています。
![2015-06-16 20 43 58](https://cloud.githubusercontent.com/assets/9944/8182251/a35c3378-1468-11e5-8fe5-ffd8865e2352.png)
